### PR TITLE
README: The default branch is main, not master

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Also, add the following Symbol/Footprint library to KiCAD: [https://github.com/O
 
 ## BOM
 
-See: [https://htmlpreview.github.io/?https://github.com/Open-Smartwatch/open-smartwatch-light/blob/master/docs/bom/osw-light-ibom.html](https://htmlpreview.github.io/?https://github.com/Open-Smartwatch/open-smartwatch-light/blob/master/docs/bom/osw-light-ibom.html)
+See: [https://htmlpreview.github.io/?https://github.com/Open-Smartwatch/open-smartwatch-light/blob/main/docs/bom/osw-light-ibom.html](https://htmlpreview.github.io/?https://github.com/Open-Smartwatch/open-smartwatch-light/blob/main/docs/bom/osw-light-ibom.html)


### PR DESCRIPTION
This is just reflecting the fact that the default branch is main as opposed to master, this is not really an issue as GitHub redirects to the default as master doesn't exist but might be worth fixing.